### PR TITLE
Allow for custom service type and annotations

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hollow-metadataservice
 description: Hollow Metadata Service
 type: application
-version: 0.1.9
+version: 0.1.10
 appVersion: "1.0"
 sources:
   - https://github.com/metal-toolbox/hollow-metadataservice

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -1,6 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
+{{- if .Values.service.annotations }}
+  annotations:
+    {{- toYaml .Values.service.annotations . | nindent 4 }}
+{{- end }}
   name: {{ template "common.names.fullname" . }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
@@ -14,4 +18,4 @@ spec:
     protocol: TCP
     targetPort: 8000
   selector: {{ include "common.labels.matchLabels" . | nindent 4 }}
-  type: ClusterIP
+  type: {{ .Values.service.type }}

--- a/values.yaml
+++ b/values.yaml
@@ -53,6 +53,10 @@ lookup:
     # # scopes should be formatted as white space separated strings
     # scopesFrom: {}
 
+service:
+  type: ClusterIP
+  annotations: {}
+
 serviceMonitor:
   enabled: false
 


### PR DESCRIPTION
This allows parent charts to override the service type and specify annotations.