### PR TITLE
Use app image v0.0.11

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hollow-metadataservice
 description: Hollow Metadata Service
 type: application
-version: 0.1.14
+version: 0.1.15
 appVersion: "1.0"
 sources:
   - https://github.com/metal-toolbox/hollow-metadataservice

--- a/values.yaml
+++ b/values.yaml
@@ -1,7 +1,7 @@
 metadataservice:
   image:
     repository: ghcr.io/metal-toolbox/hollow-metadataservice
-    tag: "v0.0.9"
+    tag: "v0.0.11"
   # apiURL: "https://metadata-service" ## Usually the url of the metadata service itself. Output in a metadata response as "api_url"
   # phoneHomeURL: "https://phone.{{.facility}}/phone-home" ## The URL output in the metadata response as "phone_home_url". Can be a gotmpl with references to fields contained in the metadata document.
   # userStateURL: "https://userstate.{{.facility}}/user-state" ## The URL output in the metadata response as "user_state_url". Can be a gotmpl with references to fields contained in the metadata document.


### PR DESCRIPTION
Note: v0.0.10 was broken due to goreleaser issues in the app repo, so this skips a version on purpose.