### PR TITLE
Apply securityContext settings for running as non-root

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -11,6 +11,22 @@ spec:
     metadata:
       labels: {{- include "common.labels.standard" . | nindent 8 }}
     spec:
+      initContainers:
+      - name: fix-volume-perms
+        image: busybox
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: dbcerts
+          mountPath: "/dbcerts"
+        command: ["sh", "-c", "chown -R 10001:10001 /dbcerts"]
       containers:
         - name: metadata-service
           env:
@@ -54,6 +70,10 @@ spec:
               port: http
             initialDelaySeconds: 5
             timeoutSeconds: 2
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
           resources:
 {{ toYaml .Values.resources | indent 12 }}
       volumes:


### PR DESCRIPTION
Also, use an initContainer to chown the /dbcerts volume contents so they
are readable by the application user.
