### PR TITLE
Update app image to v0.0.32

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hollow-metadataservice
 description: Hollow Metadata Service
 type: application
-version: 0.1.33
+version: 0.1.34
 appVersion: "1.0"
 sources:
   - https://github.com/metal-toolbox/hollow-metadataservice

--- a/values.yaml
+++ b/values.yaml
@@ -1,7 +1,7 @@
 metadataservice:
   image:
     repository: ghcr.io/metal-toolbox/hollow-metadataservice
-    tag: "v0.0.29"
+    tag: "v0.0.32"
   # apiURL: "https://metadata-service" ## Usually the url of the metadata service itself. Output in a metadata response as "api_url"
   # phoneHomeURL: "https://phone.{{.facility}}/phone-home" ## The URL output in the metadata response as "phone_home_url". Can be a gotmpl with references to fields contained in the metadata document.
   # userStateURL: "https://userstate.{{.facility}}/user-state" ## The URL output in the metadata response as "user_state_url". Can be a gotmpl with references to fields contained in the metadata document.


### PR DESCRIPTION
Note: the previous release was v0.0.29 because I had to burn some git tags while troubleshooting issues with goreleaser in the hollow-metadataservice repository.