### PR TITLE
Configure renovate to generate PRs when app updates are detected

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,24 @@
 {
-    "extends": [
-      "config:base"
-    ]
-  }
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base"],
+  "regexManagers": [
+    {
+      "fileMatch": ["^values\\.yaml$"],
+      "matchStrings": [
+        "metadataservice:\\s*\\n\\s*image:\\s*\\n\\s*repository:\\s*ghcr.io\\/(?<depName>metal-toolbox\\/hollow-metadataservice)\\s*\\n\\s*tag:\\s*\"?(?<currentValue>[^\"\\s]+)\"?"
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "metal-toolbox/hollow-metadataservice"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["metal-toolbox/hollow-metadataservice"],
+      "groupName": "hollow-metadataservice",
+      "commitMessageTopic": "hollow-metadataservice image",
+      "semanticCommits": "enabled",
+      "semanticCommitType": "fix",
+      "labels": ["dependencies", "helm"]
+    }
+  ]
+}


### PR DESCRIPTION
This looks for new GH releases of metal-toolbox/hollow-metadataservice and should create a PR to update values.yaml accordingly.